### PR TITLE
Environment configurable redis call TTLs

### DIFF
--- a/lib/update-call-status.js
+++ b/lib/update-call-status.js
@@ -1,8 +1,8 @@
 const {makeCallKey, noopLogger, filterNullsAndObjects, CALL_SET} = require('./utils');
 const debug = require('debug')('jambonz:realtimedb-helpers');
 const assert = require('assert');
-const MAX_CALL_LIFETIME = 12 * 60 * 60;                 // calls live 12 hours max in redis
-const MAX_CALL_LIFETIME_AFTER_COMPLETED = 1 * 60 * 60;  // or 1 hour after completion
+const MAX_CALL_LIFETIME = process.env.JAMBONES_MAX_CALL_LIFETIME || 12 * 60 * 60;                         // calls live default 12 hours max in redis
+const MAX_CALL_LIFETIME_AFTER_COMPLETED = process.env.MAX_CALL_LIFETIME_AFTER_COMPLETED || 1 * 60 * 60;   // or default 1 hour after completion
 
 // duck-type checking
 function validateCallInfo(callInfo, serviceUrl) {

--- a/lib/update-call-status.js
+++ b/lib/update-call-status.js
@@ -1,8 +1,10 @@
 const {makeCallKey, noopLogger, filterNullsAndObjects, CALL_SET} = require('./utils');
 const debug = require('debug')('jambonz:realtimedb-helpers');
 const assert = require('assert');
-const MAX_CALL_LIFETIME = process.env.JAMBONES_MAX_CALL_LIFETIME || 12 * 60 * 60;                         // calls live default 12 hours max in redis
-const MAX_CALL_LIFETIME_AFTER_COMPLETED = process.env.MAX_CALL_LIFETIME_AFTER_COMPLETED || 1 * 60 * 60;   // or default 1 hour after completion
+// calls live default 12 hours max in redis
+const MAX_CALL_LIFETIME = process.env.JAMBONES_MAX_CALL_LIFETIME || 12 * 60 * 60;
+// or default 1 hour after completion
+const MAX_CALL_LIFETIME_AFTER_COMPLETED = process.env.JAMBONES_MAX_CALL_LIFETIME_AFTER_COMPLETED || 1 * 60 * 60;
 
 // duck-type checking
 function validateCallInfo(callInfo, serviceUrl) {


### PR DESCRIPTION
Optionally configure `MAX_CALL_LIFETIME` and `MAX_CALL_LIFETIME_AFTER_COMPLETED` key TTL by setting respective `JAMBONES_MAX_CALL_LIFETIME` and `JAMBONES_MAX_CALL_LIFETIME_AFTER_COMPLETED` environment variables.