### PR TITLE
set lock on purge run

### DIFF
--- a/lib/purge-calls.js
+++ b/lib/purge-calls.js
@@ -1,4 +1,4 @@
-const {CALL_SET, noopLogger} = require('./utils');
+const {CALL_SET, PURGE_CALLS_LOCK_KEY, noopLogger} = require('./utils');
 const debug = require('debug')('jambonz:realtimedb-helpers');
 
 /**
@@ -8,6 +8,11 @@ async function purgeCalls(client, logger) {
   logger = logger || noopLogger;
   let purgedCount = 0;
   try {
+    if (await client.getAsync(PURGE_CALLS_LOCK_KEY)) {
+      return;
+    }
+    // set run lock
+    await client.setAsync(PURGE_CALLS_LOCK_KEY, 'locked', 'EX', 1 * 60);
     const dead = [];
     const count = await client.zcardAsync(CALL_SET);
     debug(`purgeCalls: scanning ${count} members of active call set`);
@@ -41,6 +46,7 @@ async function purgeCalls(client, logger) {
     do {
       cursor = await scan(cursor);
     } while ('0' !== cursor);
+    await client.delAsync(PURGE_CALLS_LOCK_KEY);
   } catch (err) {
     debug(err, 'purgeCalls: Error');
     logger.error(err, 'purgeCalls: Error');

--- a/lib/purge-calls.js
+++ b/lib/purge-calls.js
@@ -8,11 +8,11 @@ async function purgeCalls(client, logger) {
   logger = logger || noopLogger;
   let purgedCount = 0;
   try {
-    if (await client.getAsync(PURGE_CALLS_LOCK_KEY)) {
+    // set run lock
+    const result = await client.setAsync(PURGE_CALLS_LOCK_KEY, 'locked', 'NX', 'EX', 1 * 60);
+    if (!result) {
       return;
     }
-    // set run lock
-    await client.setAsync(PURGE_CALLS_LOCK_KEY, 'locked', 'EX', 1 * 60);
     const dead = [];
     const count = await client.zcardAsync(CALL_SET);
     debug(`purgeCalls: scanning ${count} members of active call set`);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,5 +55,6 @@ module.exports = {
   makePatternForQueueScan,
   noopLogger,
   filterNullsAndObjects,
-  CALL_SET: 'active-call-sids'
+  CALL_SET: 'active-call-sids',
+  PURGE_CALLS_LOCK_KEY: 'purge-calls-lock'
 };

--- a/test/calls.js
+++ b/test/calls.js
@@ -163,6 +163,9 @@ test('calls tests', async(t) => {
 
     count = await purgeCalls();
     t.ok(count === 0, 'no calls purged');
+  
+    const [res1, res2] = await Promise.all([purgeCalls(), new Promise(resolve => setTimeout(resolve, 100)).then(() => purgeCalls())]);
+    t.ok(res1 === 0 && res2 == undefined, 'successfully handle simultaneous purgeCalls run');
 
     calls = await listCalls('account-1');
     t.ok(calls.length === 1000, 'successfully retrieved all 1,000 calls');


### PR DESCRIPTION
Set lock for purgeCall run, this helps not to run the same task when Jambonz deployment has more than one API server. 