### PR TITLE
Expires uses incorrect MAX_CALL_LIFETIME for completed calls

### DIFF
--- a/lib/update-call-status.js
+++ b/lib/update-call-status.js
@@ -31,7 +31,7 @@ async function updateCallStatus(client, logger, callInfo, serviceUrl) {
     validateCallInfo(callInfo, serviceUrl);
     const {accountSid, callSid} = callInfo;
     const key = makeCallKey(accountSid, callSid);
-    const expires = callInfo.sipStatus >= 200 ? MAX_CALL_LIFETIME : MAX_CALL_LIFETIME_AFTER_COMPLETED;
+    const expires = callInfo.sipStatus >= 200 ?  MAX_CALL_LIFETIME_AFTER_COMPLETED : MAX_CALL_LIFETIME;
     const obj = callInfo.sipStatus === 100 ? Object.assign({serviceUrl}, callInfo) : callInfo;
 
     // remove null values


### PR DESCRIPTION
MAX_CALL_LIFETIME & MAX_CALL_LIFETIME_AFTER_COMPLETED are round the wrong way when determining expires for a call being saved to redis.

This means that redis contains a large amount of calls after they have completed for up to 12hrs. 

Another side effect is that the purge-calls function works overtime to clean up a large amount of calls putting load on the redis cluster. 