### PR TITLE
Add helper function to only decrement a key if it exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,7 @@ module.exports = (opts, logger) => {
     deleteKey: require('./lib/key/delete-key').bind(null, client, logger),
     incrKey: require('./lib/key/incr').bind(null, client, logger),
     decrKey: require('./lib/key/decr').bind(null, client, logger),
+    decrKeyIfExists: require('./lib/key/decr-key-if-exists').bind(null, client, logger),
     pushBack: require('./lib/list/push-back').bind(null, client, logger),
     lengthOfList: require('./lib/list/length').bind(null, client, logger),
     getListPosition: require('./lib/list/position').bind(null, client, logger),

--- a/lib/key/decr-key-if-exists.js
+++ b/lib/key/decr-key-if-exists.js
@@ -1,0 +1,19 @@
+const { noopLogger } = require('../utils');
+const debug = require('debug')('jambonz:realtimedb-helpers');
+
+async function decrKeyIfExists(client, logger, key, expires = 0) {
+  logger = logger || noopLogger;
+  try {
+    const exists = await client.exists(key);
+    if (!exists) { return 0; }
+
+    const result = await client.decr(key);
+    debug(result, `result from decrementing key ${key}`);
+    return result;
+  } catch (err) {
+    debug(err, 'result from decrementing key');
+    logger.error(err, `addKey: error decrementing ${key}`);
+  }
+}
+
+module.exports = decrKeyIfExists;

--- a/test/key.js
+++ b/test/key.js
@@ -16,7 +16,7 @@ process.on('unhandledRejection', (reason, p) => {
 
 test('key tests', async(t) => {
   const fn = require('..');
-  const {addKey, addKeyNx, deleteKey, retrieveKey, incrKey, decrKey, client} = fn(opts);
+  const {addKey, addKeyNx, deleteKey, retrieveKey, incrKey, decrKey, decrKeyIfExists, client} = fn(opts);
 
   try {
     let result = await addKey('akey', 'value');
@@ -49,8 +49,19 @@ test('key tests', async(t) => {
     result = await decrKey('mykey');
     t.ok(result === 1, 'decrKey works properly when key exists');
   
+    result = await decrKeyIfExists('mykey')
+    t.ok(result === 0, 'decrKeyIfExists works properly when key exists');
+
     result = await decrKey('nokey');
     t.ok(result === -1, 'decrKey returns -1 when key did not exist');
+    // Delete key again, because DECR command creates key if it does not exists
+    await deleteKey('nokey')
+    
+    result = await decrKeyIfExists('nokey');
+    t.ok(result === 0, 'decrKeyIfExists returns 0 when key did not exist')
+    
+    result = await retrieveKey('nokey')
+    t.ok(result === null, 'decrKeyIfExists does not create a key when key did not exist')
 
     result = await incrKey('mykey-now', 1);
     t.ok(result === 1, 'incrKey increments key with expires');


### PR DESCRIPTION
This helper function checks if a certain key exists and only if that's the case, it decrements the value of the key. This is in contrast to the normal Redis DECR command which creates a new key, if it notices that the key does not exist and sets the value of the key to `0` by default.