### PR TITLE
fix: pipeline EXISTS checks in purgeCalls to avoid O(N) round-trips

### DIFF
--- a/lib/purge-calls.js
+++ b/lib/purge-calls.js
@@ -13,7 +13,6 @@ async function purgeCalls(client, logger) {
     if (!result) {
       return;
     }
-    const dead = [];
     const count = await client.zcard(CALL_SET);
     debug(`purgeCalls: scanning ${count} members of active call set`);
     logger.info(`purgeCalls: scanning ${count} members of active call set`);
@@ -21,18 +20,31 @@ async function purgeCalls(client, logger) {
     async function scan(cursor) {
       try {
         const res = await client.zscan([CALL_SET, cursor, 'COUNT', 500]);
+        const keys = [];
         for (let i = 0; i < res[1].length; i += 2) {
-          const key = res[1][i];
-          const exists = await client.exists(key);
-          debug(`key ${key} exists: ${exists}`);
-          if (!exists) dead.push(key);
+          keys.push(res[1][i]);
         }
 
-        if (dead.length) {
-          logger.info(`purgeCalls: removing ${dead.length} keys`);
-          const result = await client.zrem(CALL_SET, dead);
-          logger.debug(`purgeCalls: removed ${result} keys`);
-          purgedCount += dead.length;
+        if (keys.length) {
+          // Pipeline EXISTS checks - single round-trip for entire batch
+          const pipeline = client.pipeline();
+          keys.forEach((key) => pipeline.exists(key));
+          const results = await pipeline.exec();
+
+          const dead = [];
+          results.forEach((result, idx) => {
+            // result is [err, value] - value is 0 if key doesn't exist
+            if (!result[0] && !result[1]) {
+              dead.push(keys[idx]);
+            }
+          });
+
+          if (dead.length) {
+            debug(`purgeCalls: removing ${dead.length} dead keys from batch of ${keys.length}`);
+            const removed = await client.zrem(CALL_SET, dead);
+            logger.debug(`purgeCalls: removed ${removed} keys`);
+            purgedCount += dead.length;
+          }
         }
         return res[0];  // return updated cursor
       } catch (err) {

--- a/test/docker_start.js
+++ b/test/docker_start.js
@@ -2,7 +2,7 @@ const test = require('tape').test ;
 const exec = require('child_process').exec ;
 
 test('starting docker network..', (t) => {
-  exec(`docker-compose -f ${__dirname}/docker-compose-testbed.yaml up -d`, (err, stdout, stderr) => {
+  exec(`docker compose -f ${__dirname}/docker-compose-testbed.yaml up -d`, (err, stdout, stderr) => {
     setTimeout(() => {
       t.end(err);
     }, 2000);

--- a/test/docker_stop.js
+++ b/test/docker_stop.js
@@ -3,7 +3,7 @@ const exec = require('child_process').exec ;
 
 test('stopping docker network..', (t) => {
   t.timeoutAfter(10000);
-  exec(`docker-compose -f ${__dirname}/docker-compose-testbed.yaml down`, (err, stdout, stderr) => {
+  exec(`docker compose -f ${__dirname}/docker-compose-testbed.yaml down`, (err, stdout, stderr) => {
     //console.log(`stderr: ${stderr}`);
     process.exit(0);
   });


### PR DESCRIPTION
## Summary

- Pipeline EXISTS checks in `purgeCalls` using ioredis `pipeline()` to batch all checks into a single round-trip per ZSCAN batch
- Reduces Redis round-trips from O(N) to O(N/500) for the active-call-sids ZSET
- Fixes subtle bug where `dead` array accumulated across scan iterations

## Background

Customer reported API server outages caused by `purgeCalls` blocking. The `active-call-sids` ZSET had grown to 2,200–4,400 members with ~67% dead entries. The previous implementation did sequential `await client.exists(key)` for each member, creating ~1.1M Redis read storms that wedged workers.

## Test plan

- [x] All 124 tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.ai/code)